### PR TITLE
Evitando crash do app pelo autofill de cartão

### DIFF
--- a/src/CreditCardInput.js
+++ b/src/CreditCardInput.js
@@ -40,6 +40,7 @@ const CARD_NUMBER_INPUT_WIDTH = Dimensions.get("window").width - EXPIRY_INPUT_WI
 const NAME_INPUT_WIDTH = CARD_NUMBER_INPUT_WIDTH;
 const PREVIOUS_FIELD_OFFSET = 40;
 const POSTAL_CODE_INPUT_WIDTH = 120;
+const FOCUS_TIMEOUT = 1000;
 
 /* eslint react/prop-types: 0 */ // https://github.com/yannickcr/eslint-plugin-react/issues/106
 export default class CreditCardInput extends Component {
@@ -94,10 +95,22 @@ export default class CreditCardInput extends Component {
     additionalInputsProps: {},
   };
 
+  static lastFocusedProps = "";
+  static lastFocused = "";
+
   componentDidMount = () => this._focus(this.props.focused);
 
   componentWillReceiveProps = newProps => {
-    if (this.props.focused !== newProps.focused) this._focus(newProps.focused);
+    if (this.props.focused !== newProps.focused) {
+      this.lastFocusedProps = newProps.focused;
+
+      setTimeout(() => {
+        if (this.lastFocused !== this.lastFocusedProps) {
+          this._focus(this.lastFocusedProps);
+          this.lastFocused = this.lastFocusedProps;
+        }
+      }, FOCUS_TIMEOUT);
+    }
   };
 
   _focus = field => {
@@ -110,8 +123,8 @@ export default class CreditCardInput extends Component {
       e => { throw e; },
       x => {
         scrollResponder.scrollTo({ x: Math.max(x - PREVIOUS_FIELD_OFFSET, 0), animated: true });
-        this.refs[field].focus();
       });
+      this.refs[field].focus();
   }
 
   _inputProps = field => {


### PR DESCRIPTION
Este commit aplica a solução apresentada na tarefa* para evitar que, quando for utilizado preenchimento automático, a alteração de foco entre os campos cause um loop de mudança de campo que eventualmente quebrará o app.

A solução verifica se o campo que o foco vai ser alterado é o mesmo campo que já possuía o foco anteriormente, caso não seja o foco pode ser alterado. Esta ação possui um timeout de 1 segundo.

\* [(2/8) Autocomplete do cartão não funciona e quebra o app](https://trello.com/c/ljLnu8Jn/280-2-8-autocomplete-do-cart%C3%A3o-n%C3%A3o-funciona-e-quebra-o-app)

**Obs: esse PR precisa ser aprovado para liberação de release para ser usado no projeto mobile** 